### PR TITLE
use l,m to compute a in Ma_from_fQ()

### DIFF
--- a/ringdown.py
+++ b/ringdown.py
@@ -194,7 +194,7 @@ def Ma_from_fQ(f, Q, l=2, m=2):
     """return BH mass and spin given ringdown quality and freq
     for mode l,m; currently only l=2,3,4
     """
-    a = a_from_Q(Q)
+    a = a_from_Q(Q, l, m)
     F = F_from_a(a, l, m)
     M = F / (2.0*np.pi*f) / __Tsun
     return (M, a)


### PR DESCRIPTION
`l` and `m` were not passed to `a_from_Q()` when it was called in `Ma_from_fQ()`.  This resulted in `a` always being determined for the fundamental `l=m=2` mode, even if the user specified something else. 